### PR TITLE
Adding Danish translation

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -11,7 +11,7 @@
     <string name="repeated_description">Tillad et tredje opkald fra det samme nummer inde for fem minutter. På grund af opkalds-screening cachen, skal opkald være ude af cacheintervallet.</string>
     <string name="service_unavailable_toast">Opkalds-screeningstjeneste utilgængelig</string>
     <string name="sms_switch">SMS</string>
-    <string name="sms_description">Tillad midlertidige numre fra indgående tekstbeskeder.</string>
+    <string name="sms_description">Tillad midlertidige mobilnumre fra indgående tekstbeskeder.</string>
     <string name="stir_switch">STIR/SHAKEN</string>
     <string name="stir_description">Tillad numre der har bestået STIR-verificering.</string>
 </resources>


### PR DESCRIPTION
Let me know if anything is wrong and need fixing. :)

I exluded mobile in 14 because I thought it was implied in the other strings and didn't necessarily need to be in that single string. Just say if you want it put back in.