### PR TITLE
LineageOS "ContentResolver.query" problem workaround and "Silence Call" improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "me.lucky.silence"

--- a/app/src/main/java/me/lucky/silence/screening/CallScreeningHelper.kt
+++ b/app/src/main/java/me/lucky/silence/screening/CallScreeningHelper.kt
@@ -107,14 +107,16 @@ class CallScreeningHelper(private val ctx: Context) {
 
     private fun checkRepeated(number: Phonenumber.PhoneNumber, callDetails: Call.Details): Boolean {
         val cursor: Cursor?
-        val disallowCall = prefs.responseOptions.and(ResponseOption.DisallowCall.value) != 0
+        val type = CallLog.Calls.TYPE
         try {
             cursor = ctx.contentResolver.query(
                 makeContentUri(CallLog.Calls.CONTENT_FILTER_URI, number),
                 arrayOf(CallLog.Calls._ID, CallLog.Calls.DATE),
-                (if (disallowCall) "${CallLog.Calls.TYPE} = ${CallLog.Calls.BLOCKED_TYPE} AND " else "") +
+                "(${type} = ${CallLog.Calls.BLOCKED_TYPE} OR " +
+                            "${type} = ${CallLog.Calls.MISSED_TYPE} OR " +
+                            "${type} = ${CallLog.Calls.REJECTED_TYPE}) AND " +
                         "${CallLog.Calls.DATE} > " +
-                        (System.currentTimeMillis() - prefs.repeatedMinutes * 60 * 1000).toString(),
+                            (System.currentTimeMillis() - prefs.repeatedMinutes * 60 * 1000).toString(),
                 null,
                 CallLog.Calls.DEFAULT_SORT_ORDER,
             )

--- a/app/src/main/java/me/lucky/silence/screening/CallScreeningHelper.kt
+++ b/app/src/main/java/me/lucky/silence/screening/CallScreeningHelper.kt
@@ -3,15 +3,19 @@ package me.lucky.silence.screening
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
+import android.os.Build
 import android.provider.CallLog
 import android.provider.ContactsContract
 import android.provider.Telephony
 import android.telecom.Call
 import android.telephony.TelephonyManager
-
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.google.i18n.phonenumbers.Phonenumber
-import me.lucky.silence.*
+import me.lucky.silence.AppDatabase
+import me.lucky.silence.Contact
+import me.lucky.silence.Group
+import me.lucky.silence.Message
+import me.lucky.silence.Preferences
 
 class CallScreeningHelper(private val ctx: Context) {
     private val telephonyManager = ctx.getSystemService(TelephonyManager::class.java)
@@ -53,7 +57,7 @@ class CallScreeningHelper(private val ctx: Context) {
                 null,
                 null,
             )
-        } catch (exc: SecurityException) {}
+        } catch (_: SecurityException) {}
         cursor?.apply {
             if (moveToFirst()) result = true
             close()
@@ -64,18 +68,25 @@ class CallScreeningHelper(private val ctx: Context) {
     private fun checkContactedMessage(number: Phonenumber.PhoneNumber): Boolean {
         var cursor: Cursor? = null
         var result = false
+        val formatedNumber = phoneNumberUtil.format(
+            number,
+            PhoneNumberUtil.PhoneNumberFormat.E164,
+        )
+        var selection = "${Telephony.Sms.ADDRESS} = ?"
+        var selectionArgs: Array<String>? = arrayOf(formatedNumber)
+        if (isRequireQueryFix()) {
+            selection = selection.replace("?", formatedNumber)
+            selectionArgs = null
+        }
         try {
             cursor = ctx.contentResolver.query(
                 Telephony.Sms.Sent.CONTENT_URI,
                 arrayOf(Telephony.Sms._ID),
-                "${Telephony.Sms.ADDRESS} = " + phoneNumberUtil.format(
-                    number,
-                    PhoneNumberUtil.PhoneNumberFormat.E164,
-                ),
-                arrayOf(),
+                selection,
+                selectionArgs,
                 null,
             )
-        } catch (exc: SecurityException) {}
+        } catch (_: SecurityException) {}
         cursor?.apply {
             if (moveToFirst()) result = true
             close()
@@ -108,16 +119,22 @@ class CallScreeningHelper(private val ctx: Context) {
     private fun checkRepeated(number: Phonenumber.PhoneNumber, callDetails: Call.Details): Boolean {
         val cursor: Cursor?
         val type = CallLog.Calls.TYPE
+        val dateLimit = (System.currentTimeMillis() - prefs.repeatedMinutes * 60 * 1000).toString()
+        var selection = "($type = ${CallLog.Calls.BLOCKED_TYPE} OR " +
+                "$type = ${CallLog.Calls.MISSED_TYPE} OR " +
+                "$type = ${CallLog.Calls.REJECTED_TYPE}) AND " +
+                "${CallLog.Calls.DATE} > ?"
+        var selectionArgs: Array<String>? = arrayOf(dateLimit)
+        if (isRequireQueryFix()) {
+            selection = selection.replace("?", dateLimit)
+            selectionArgs = null
+        }
         try {
             cursor = ctx.contentResolver.query(
                 makeContentUri(CallLog.Calls.CONTENT_FILTER_URI, number),
                 arrayOf(CallLog.Calls._ID, CallLog.Calls.DATE),
-                "(${type} = ${CallLog.Calls.BLOCKED_TYPE} OR " +
-                            "${type} = ${CallLog.Calls.MISSED_TYPE} OR " +
-                            "${type} = ${CallLog.Calls.REJECTED_TYPE}) AND " +
-                        "${CallLog.Calls.DATE} > " +
-                            (System.currentTimeMillis() - prefs.repeatedMinutes * 60 * 1000).toString(),
-                null,
+                selection,
+                selectionArgs,
                 CallLog.Calls.DEFAULT_SORT_ORDER,
             )
         } catch (exc: SecurityException) { return false }
@@ -165,18 +182,25 @@ class CallScreeningHelper(private val ctx: Context) {
             return false
         var cursor: Cursor? = null
         var result = false
+        val formatedNumber = phoneNumberUtil.format(
+            number,
+            PhoneNumberUtil.PhoneNumberFormat.E164,
+        )
+        var selection = "${Telephony.Sms.ADDRESS} = ?"
+        var selectionArgs: Array<String>? = arrayOf(formatedNumber)
+        if (isRequireQueryFix()) {
+            selection = selection.replace("?", formatedNumber)
+            selectionArgs = null
+        }
         try {
             cursor = ctx.contentResolver.query(
                 Telephony.Sms.Inbox.CONTENT_URI,
                 arrayOf(Telephony.Sms._ID),
-                "${Telephony.Sms.ADDRESS} = " + phoneNumberUtil.format(
-                    number,
-                    PhoneNumberUtil.PhoneNumberFormat.E164,
-                ),
-                null,
+                selection,
+                selectionArgs,
                 null,
             )
-        } catch (exc: SecurityException) {}
+        } catch (_: SecurityException) {}
         cursor?.apply {
             if (moveToFirst()) result = true
             close()
@@ -222,4 +246,7 @@ class CallScreeningHelper(private val ctx: Context) {
                 PhoneNumberUtil.PhoneNumberFormat.E164,
             )),
         )
+
+    private fun isRequireQueryFix() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2 &&
+            Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU
 }

--- a/app/src/main/java/me/lucky/silence/screening/CallScreeningHelper.kt
+++ b/app/src/main/java/me/lucky/silence/screening/CallScreeningHelper.kt
@@ -107,11 +107,13 @@ class CallScreeningHelper(private val ctx: Context) {
 
     private fun checkRepeated(number: Phonenumber.PhoneNumber, callDetails: Call.Details): Boolean {
         val cursor: Cursor?
+        val disallowCall = prefs.responseOptions.and(ResponseOption.DisallowCall.value) != 0
         try {
             cursor = ctx.contentResolver.query(
                 makeContentUri(CallLog.Calls.CONTENT_FILTER_URI, number),
                 arrayOf(CallLog.Calls._ID, CallLog.Calls.DATE),
-                "${CallLog.Calls.TYPE} = ${CallLog.Calls.BLOCKED_TYPE} AND ${CallLog.Calls.DATE} > " +
+                (if (disallowCall) "${CallLog.Calls.TYPE} = ${CallLog.Calls.BLOCKED_TYPE} AND " else "") +
+                        "${CallLog.Calls.DATE} > " +
                         (System.currentTimeMillis() - prefs.repeatedMinutes * 60 * 1000).toString(),
                 null,
                 CallLog.Calls.DEFAULT_SORT_ORDER,

--- a/app/src/main/java/me/lucky/silence/screening/CallScreeningHelper.kt
+++ b/app/src/main/java/me/lucky/silence/screening/CallScreeningHelper.kt
@@ -49,8 +49,8 @@ class CallScreeningHelper(private val ctx: Context) {
             cursor = ctx.contentResolver.query(
                 makeContentUri(CallLog.Calls.CONTENT_FILTER_URI, number),
                 arrayOf(CallLog.Calls._ID),
-                "${CallLog.Calls.TYPE} = ?",
-                arrayOf(CallLog.Calls.OUTGOING_TYPE.toString()),
+                "${CallLog.Calls.TYPE} = ${CallLog.Calls.OUTGOING_TYPE}",
+                null,
                 null,
             )
         } catch (exc: SecurityException) {}
@@ -68,11 +68,11 @@ class CallScreeningHelper(private val ctx: Context) {
             cursor = ctx.contentResolver.query(
                 Telephony.Sms.Sent.CONTENT_URI,
                 arrayOf(Telephony.Sms._ID),
-                "${Telephony.Sms.ADDRESS} = ?",
-                arrayOf(phoneNumberUtil.format(
+                "${Telephony.Sms.ADDRESS} = " + phoneNumberUtil.format(
                     number,
                     PhoneNumberUtil.PhoneNumberFormat.E164,
-                )),
+                ),
+                arrayOf(),
                 null,
             )
         } catch (exc: SecurityException) {}
@@ -111,11 +111,9 @@ class CallScreeningHelper(private val ctx: Context) {
             cursor = ctx.contentResolver.query(
                 makeContentUri(CallLog.Calls.CONTENT_FILTER_URI, number),
                 arrayOf(CallLog.Calls._ID, CallLog.Calls.DATE),
-                "${CallLog.Calls.TYPE} = ? AND ${CallLog.Calls.DATE} > ?",
-                arrayOf(
-                    CallLog.Calls.BLOCKED_TYPE.toString(),
-                    (System.currentTimeMillis() - prefs.repeatedMinutes * 60 * 1000).toString(),
-                ),
+                "${CallLog.Calls.TYPE} = ${CallLog.Calls.BLOCKED_TYPE} AND ${CallLog.Calls.DATE} > " +
+                        (System.currentTimeMillis() - prefs.repeatedMinutes * 60 * 1000).toString(),
+                null,
                 CallLog.Calls.DEFAULT_SORT_ORDER,
             )
         } catch (exc: SecurityException) { return false }
@@ -167,11 +165,11 @@ class CallScreeningHelper(private val ctx: Context) {
             cursor = ctx.contentResolver.query(
                 Telephony.Sms.Inbox.CONTENT_URI,
                 arrayOf(Telephony.Sms._ID),
-                "${Telephony.Sms.ADDRESS} = ?",
-                arrayOf(phoneNumberUtil.format(
+                "${Telephony.Sms.ADDRESS} = " + phoneNumberUtil.format(
                     number,
                     PhoneNumberUtil.PhoneNumberFormat.E164,
-                )),
+                ),
+                null,
                 null,
             )
         } catch (exc: SecurityException) {}


### PR DESCRIPTION
Concerning the first commit: after lots of consideration I think that although inserting arguments directly into the SQL query line is "a very bad idea", in this particular case it has almost no security implications as it is virtually impossible to inject garbage (or at least useful garbage) into a phone number. When weighing this very unlikely security flaw against the restored functionality under LineageOS 19.x and 20.x (or may be some other systems) I think it's worth it.

The other two commits are some improvements to the repeated call functionality, particularly related to the "Silence call" function.