### PR TITLE
Support call blocking/allowing based on configured REGEX expressions

### DIFF
--- a/app/src/main/java/me/lucky/silence/Preferences.kt
+++ b/app/src/main/java/me/lucky/silence/Preferences.kt
@@ -37,7 +37,9 @@ class Preferences(ctx: Context) {
         const val SERVICE_ENABLED = "service_enabled"
         const val GENERAL_UNKNOWN_NUMBERS_CHECKED = "general_unknown_numbers_checked"
 
-        const val REGEX_PATTERN = "regex_pattern"
+        const val REGEX_PATTERN_ALLOW = "regex_pattern_allow"
+
+        const val REGEX_PATTERN_BLOCK = "regex_pattern_block"
     }
 
     private val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
@@ -128,9 +130,13 @@ class Preferences(ctx: Context) {
         get() = prefs.getBoolean(BLOCK_ENABLED, false)
         set(value) = prefs.edit { putBoolean(BLOCK_ENABLED, value) }
 
-    var regexPattern: String?
-        get() = prefs.getString(REGEX_PATTERN, "")
-        set(value) = prefs.edit { putString(REGEX_PATTERN, value) }
+    var regexPatternAllow: String?
+        get() = prefs.getString(REGEX_PATTERN_ALLOW, "")
+        set(value) = prefs.edit { putString(REGEX_PATTERN_ALLOW, value) }
+
+    var regexPatternBlock: String?
+        get() = prefs.getString(REGEX_PATTERN_BLOCK, "")
+        set(value) = prefs.edit { putString(REGEX_PATTERN_BLOCK, value) }
 }
 
 enum class Contact(val value: Int) {

--- a/app/src/main/java/me/lucky/silence/screening/CallScreeningService.kt
+++ b/app/src/main/java/me/lucky/silence/screening/CallScreeningService.kt
@@ -54,6 +54,9 @@ class CallScreeningService : CallScreeningService() {
         } else if (callDetails.callDirection != Call.Details.DIRECTION_INCOMING) {
             respondAllow(callDetails)
             return
+        } else if (checkAllowRegex(callDetails)) {
+            respondAllow(callDetails)
+            return
         } else if (
             prefs.isBlockEnabled ||
             checkBlockRegex(callDetails)
@@ -158,9 +161,28 @@ class CallScreeningService : CallScreeningService() {
     private fun isNotPlusNumber(callDetails: Call.Details) =
         callDetails.handle?.schemeSpecificPart?.startsWith('+') == false
 
+    private fun checkAllowRegex(callDetails: Call.Details): Boolean {
+        val phoneNumber = callDetails.handle?.schemeSpecificPart ?: return false
+        val regexPatterns = prefs.regexPatternAllow?.split(",")?.map { it.trim() } ?: return false
+
+        // Check if any of the regex patterns match the phone number
+        for (pattern in regexPatterns) {
+            try {
+                if (pattern.toRegex(RegexOption.MULTILINE).matches(phoneNumber)) {
+                    return true // Match found, allow the call
+                }
+            } catch (exc: java.util.regex.PatternSyntaxException) {
+                // Ignore invalid patterns; continue checking others
+            }
+        }
+
+        // No matches found
+        return false
+    }
+
     private fun checkBlockRegex(callDetails: Call.Details): Boolean {
         val phoneNumber = callDetails.handle?.schemeSpecificPart ?: return false
-        val regexPatterns = prefs.regexPattern?.split(",")?.map { it.trim() } ?: return false
+        val regexPatterns = prefs.regexPatternBlock?.split(",")?.map { it.trim() } ?: return false
 
         // Check if any of the regex patterns match the phone number
         for (pattern in regexPatterns) {

--- a/app/src/main/java/me/lucky/silence/screening/CallScreeningService.kt
+++ b/app/src/main/java/me/lucky/silence/screening/CallScreeningService.kt
@@ -160,6 +160,20 @@ class CallScreeningService : CallScreeningService() {
 
     private fun checkBlockRegex(callDetails: Call.Details): Boolean {
         val phoneNumber = callDetails.handle?.schemeSpecificPart ?: return false
-        return prefs.regexPattern?.toRegex(RegexOption.MULTILINE)?.matchEntire(phoneNumber) != null
+        val regexPatterns = prefs.regexPattern?.split(",")?.map { it.trim() } ?: return false
+
+        // Check if any of the regex patterns match the phone number
+        for (pattern in regexPatterns) {
+            try {
+                if (pattern.toRegex(RegexOption.MULTILINE).matches(phoneNumber)) {
+                    return true // Match found, block the call
+                }
+            } catch (exc: java.util.regex.PatternSyntaxException) {
+                // Ignore invalid patterns; continue checking others
+            }
+        }
+
+        // No matches found
+        return false
     }
 }

--- a/app/src/main/java/me/lucky/silence/ui/RegexScreen.kt
+++ b/app/src/main/java/me/lucky/silence/ui/RegexScreen.kt
@@ -1,6 +1,8 @@
 package me.lucky.silence.ui
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
@@ -25,36 +27,69 @@ import me.lucky.silence.ui.common.Screen
 @Composable
 fun RegexScreen(prefs: Preferences, onBackPressed: () -> Boolean) {
     val regexErrorHint = stringResource(R.string.regex_pattern_error)
-    var regexError by remember { mutableStateOf(false) }
-    val regexDescription = stringResource(R.string.regex_pattern_helper_text)
-    var regexSupportingText by remember { mutableStateOf(regexDescription) }
-    var regexText by remember { mutableStateOf(prefs.regexPattern ?: "") }
+    var regexAllowError by remember { mutableStateOf(false) }
+    var regexBlockError by remember { mutableStateOf(false) }
+    val regexAllowedDescription = stringResource(R.string.regex_pattern_allow_helper_text)
+    var regexAllowedSupportingText by remember { mutableStateOf(regexAllowedDescription) }
+    val regexBlockedDescription = stringResource(R.string.regex_pattern_block_helper_text)
+    var regexBlockedSupportingText by remember { mutableStateOf(regexBlockedDescription) }
+    var regexAllowText by remember { mutableStateOf(prefs.regexPatternAllow ?: "") }
+    var regexBlockText by remember { mutableStateOf(prefs.regexPatternBlock ?: "") }
 
     Screen(title = R.string.regex_main, onBackPressed = onBackPressed, content = {
-        Row(modifier = Modifier.padding(horizontal = 8.dp)) {
-            OutlinedTextField(
-                label = { Text(stringResource(R.string.regex_pattern_hint)) },
-                supportingText = { Text(regexSupportingText) },
-                singleLine = false,
-                value = regexText,
-                isError = regexError,
-                onValueChange = { newValue ->
-                    regexError = !isValidRegex(newValue)
-                    if (regexError) {
-                        regexSupportingText = regexErrorHint
-                    } else {
-                        regexSupportingText = regexDescription
-                        prefs.regexPattern = newValue
-                    }
-                    regexText = newValue
-                },
-                modifier = Modifier.weight(1f),
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Ascii,
-                    autoCorrect = false,
-                    capitalization = KeyboardCapitalization.None
+        Column  {
+            Row(modifier = Modifier.padding(horizontal = 8.dp)) {
+                OutlinedTextField(
+                    label = { Text(stringResource(R.string.regex_pattern_allow_hint)) },
+                    supportingText = { Text(regexAllowedSupportingText) },
+                    singleLine = false,
+                    value = regexAllowText,
+                    isError = regexAllowError,
+                    onValueChange = { newValue ->
+                        regexAllowError = !isValidRegex(newValue)
+                        if (regexAllowError) {
+                            regexAllowedSupportingText = regexErrorHint
+                        } else {
+                            regexAllowedSupportingText = regexAllowedDescription
+                            prefs.regexPatternAllow = newValue
+                        }
+                        regexAllowText = newValue
+                    },
+                    modifier = Modifier.weight(1f),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Ascii,
+                        autoCorrect = false,
+                        capitalization = KeyboardCapitalization.None
+                    )
                 )
-            )
+            }
+            Spacer(modifier = Modifier.padding(vertical = 12.dp))
+            Row(modifier = Modifier.padding(horizontal = 8.dp)) {
+                OutlinedTextField(
+                    label = { Text(stringResource(R.string.regex_pattern_block_hint)) },
+                    supportingText = { Text(regexBlockedSupportingText) },
+                    singleLine = false,
+                    value = regexBlockText,
+                    isError = regexBlockError,
+                    onValueChange = { newValue ->
+                        regexBlockError = !isValidRegex(newValue)
+                        if (regexBlockError) {
+                            regexBlockedSupportingText = regexErrorHint
+                        } else {
+                            regexBlockedSupportingText = regexBlockedDescription
+                            prefs.regexPatternBlock = newValue
+                        }
+                        regexBlockText = newValue
+                    },
+                    modifier = Modifier.weight(1f),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Ascii,
+                        autoCorrect = false,
+                        capitalization = KeyboardCapitalization.None
+                    )
+                )
+            }
+
         }
     })
 }

--- a/app/src/main/java/me/lucky/silence/ui/RegexScreen.kt
+++ b/app/src/main/java/me/lucky/silence/ui/RegexScreen.kt
@@ -59,12 +59,22 @@ fun RegexScreen(prefs: Preferences, onBackPressed: () -> Boolean) {
     })
 }
 
-private fun isValidRegex(pattern: String): Boolean {
-    try {
-        pattern.toRegex(RegexOption.MULTILINE)
-    } catch (exc: java.util.regex.PatternSyntaxException) {
-        return false
+private fun isValidRegex(patterns: String): Boolean {
+    // Split the input string by commas and trim whitespace from each pattern
+    val regexPatterns = patterns.split(",").map { it.trim() }
+
+    // Validate each pattern
+    for (pattern in regexPatterns) {
+        try {
+            // Attempt to convert the pattern to a Regex object
+            pattern.toRegex(RegexOption.MULTILINE)
+        } catch (exc: java.util.regex.PatternSyntaxException) {
+            // If an exception is thrown, return false
+            return false
+        }
     }
+
+    // All patterns are valid
     return true
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,9 +22,11 @@
     <string name="groups_local_mobile">Local &amp; Mobile</string>
     <string name="groups_local_mobile_description">Allow calls from mobile numbers with the same country code as your.</string>
     <string name="regex_main">Regex</string>
-    <string name="regex_description">Process calls from numbers matching regular expression.</string>
-    <string name="regex_pattern_hint">Pattern</string>
-    <string name="regex_pattern_helper_text">Allow calls from numbers matching regular expression.</string>
+    <string name="regex_description">Process calls from numbers matching regular expressions.</string>
+    <string name="regex_pattern_allow_hint">Allow Patterns</string>
+    <string name="regex_pattern_block_hint">Block Patterns</string>
+    <string name="regex_pattern_allow_helper_text">Allow calls from numbers matching comma separated regular expressions.</string>
+    <string name="regex_pattern_block_helper_text">Block calls from numbers matching comma separated regular expressions.</string>
     <string name="regex_pattern_error">"Invalid regex!"</string>
     <string name="repeated_main">Repeated</string>
     <string name="repeated_description">Allow X registered call(s) from the same number within a set amount of minutes.</string>


### PR DESCRIPTION
This PR enhances the REGEX feature in the app.

**Usecase**: I receive alot of promotional calls from similar phone numbers. There is currently no way to block a specific phone number pattern, apart from blocking all unknown numbers. 

Existing REGEX screen only provided option to **allow** incoming calls from phone numbers matching **one** configured pattern. With this enhancement, user can **allow/block** incoming calls matching **any number** of configured REGEX patterns.

Now REGEX screen has two input text fields, one for allowed patterns, and another for blocked patterns. Both these text fields accept comma separated REGEX patterns.

**Allowed Patterns** are given higher priority than **Blocked Patterns**, i.e. If same pattern is configured in Allowed and Blocked patterns, Silence will allow the incoming call.


![Regex_Empty](https://github.com/user-attachments/assets/de0e8bd2-6f70-4dea-8a8a-9d17a134004f)
![Regex_Filled](https://github.com/user-attachments/assets/fcff9f10-4423-4c1e-842f-f4a26a7dd5b1)
