### PR TITLE
Fix: Contact permissions logic, SIM localization, and notification enhancements

### DIFF
--- a/app/src/main/java/me/lucky/silence/NotificationManager.kt
+++ b/app/src/main/java/me/lucky/silence/NotificationManager.kt
@@ -1,7 +1,9 @@
 package me.lucky.silence
 
 import android.content.Context
+import android.net.Uri
 import android.os.SystemClock
+import android.provider.ContactsContract
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -22,16 +24,48 @@ class NotificationManager(private val ctx: Context) {
         ).setName(ctx.getString(R.string.notification_channel)).build())
     }
 
+    private fun getContactName(phoneNumber: String): String? {
+        val uri = Uri.withAppendedPath(
+            ContactsContract.PhoneLookup.CONTENT_FILTER_URI,
+            Uri.encode(phoneNumber)
+        )
+        val cursor = try {
+            ctx.contentResolver.query(
+                uri,
+                arrayOf(ContactsContract.PhoneLookup.DISPLAY_NAME),
+                null,
+                null,
+                null
+            )
+        } catch (_: SecurityException) {
+            null
+        }
+        
+        var contactName: String? = null
+        cursor?.use {
+            if (it.moveToFirst()) {
+                contactName = it.getString(
+                    it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.DISPLAY_NAME)
+                )
+            }
+        }
+        return contactName
+    }
+
     fun notifyBlockedCall(tel: String, sim: Sim?) {
         var title = ctx.getString(R.string.notification_title)
         if (sim != null) title = "$title (${sim.name.replace('_', ' ')})"
+        
+        val contactName = getContactName(tel)
+        val displayText = contactName ?: tel
+        
         try {
             manager.notify(
                 SystemClock.uptimeMillis().toInt(),
                 NotificationCompat.Builder(ctx, CHANNEL_BLOCKED_CALLS_ID)
                     .setSmallIcon(R.drawable.ic_tile)
                     .setContentTitle(title)
-                    .setContentText(tel)
+                    .setContentText(displayText)
                     .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                     .setCategory(NotificationCompat.CATEGORY_STATUS)
                     .setShowWhen(true)

--- a/app/src/main/java/me/lucky/silence/Preferences.kt
+++ b/app/src/main/java/me/lucky/silence/Preferences.kt
@@ -162,7 +162,7 @@ class Preferences(ctx: Context) {
 
     private fun defaultExtra(): Int {
         var flags = 0
-        if (prefs.getBoolean(CONTACTS_CHECKED, true))
+        if (prefs.getBoolean(CONTACTS_CHECKED, false))
             flags = flags.or(Extra.CONTACTS.value)
         if (prefs.getBoolean(SHORT_NUMBERS_CHECKED, false))
             flags = flags.or(Extra.SHORT_NUMBERS.value)

--- a/app/src/main/java/me/lucky/silence/ui/ExtraScreen.kt
+++ b/app/src/main/java/me/lucky/silence/ui/ExtraScreen.kt
@@ -1,12 +1,21 @@
 package me.lucky.silence.ui
 
 import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContextCompat
 import me.lucky.silence.Extra
 import me.lucky.silence.Preferences
 import me.lucky.silence.R
@@ -16,21 +25,52 @@ import me.lucky.silence.ui.common.Screen
 
 @Composable
 fun ExtraScreen(prefs: Preferences, onBackPressed: () -> Boolean) {
+    val ctx = LocalContext.current
+    val contactsEnabledState = remember { mutableStateOf(prefs.extra.has(Extra.CONTACTS)) }
+    
+    LaunchedEffect(Unit) {
+        if (contactsEnabledState.value && ContextCompat.checkSelfPermission(ctx, Manifest.permission.READ_CONTACTS)
+            != PackageManager.PERMISSION_GRANTED) {
+            // Si estaba activado pero ya no tiene permisos, desactivarlo
+            contactsEnabledState.value = false
+            prefs.setExtra(Extra.CONTACTS, false)
+        }
+    }
+    
     val registerForContactsPermissions =
-        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
-
-    fun requestContactsPermissions() =
-        registerForContactsPermissions.launch(Manifest.permission.READ_CONTACTS)
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            contactsEnabledState.value = isGranted
+            prefs.setExtra(Extra.CONTACTS, isGranted)
+            if (!isGranted) {
+                Toast.makeText(
+                    ctx,
+                    "Contacts permission not granted",
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
 
     val preferenceList = listOf(
         Preference(
-            getValue = { prefs.extra.has(Extra.CONTACTS) },
+            getValue = { contactsEnabledState.value },
             setValue = { isChecked ->
-                prefs.setExtra(Extra.CONTACTS, isChecked)
-                if (isChecked) requestContactsPermissions()
+                if (isChecked) {
+                    if (ContextCompat.checkSelfPermission(ctx, Manifest.permission.READ_CONTACTS)
+                        == PackageManager.PERMISSION_GRANTED
+                    ) {
+                        contactsEnabledState.value = true
+                        prefs.setExtra(Extra.CONTACTS, true)
+                    } else {
+                        registerForContactsPermissions.launch(Manifest.permission.READ_CONTACTS)
+                    }
+                } else {
+                    contactsEnabledState.value = false
+                    prefs.setExtra(Extra.CONTACTS, false)
+                }
             },
             name = R.string.extra_contacts,
             description = R.string.extra_contacts_description,
+            state = contactsEnabledState,
         ), Preference(
             getValue = { prefs.extra.has(Extra.SHORT_NUMBERS) },
             setValue = { isChecked -> prefs.setExtra(Extra.SHORT_NUMBERS, isChecked) },

--- a/app/src/main/java/me/lucky/silence/ui/ExtraScreen.kt
+++ b/app/src/main/java/me/lucky/silence/ui/ExtraScreen.kt
@@ -27,7 +27,7 @@ fun ExtraScreen(prefs: Preferences, onBackPressed: () -> Boolean) {
             getValue = { prefs.extra.has(Extra.CONTACTS) },
             setValue = { isChecked ->
                 prefs.setExtra(Extra.CONTACTS, isChecked)
-                if (!isChecked) requestContactsPermissions()
+                if (isChecked) requestContactsPermissions()
             },
             name = R.string.extra_contacts,
             description = R.string.extra_contacts_description,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -42,7 +42,9 @@
     <string name="settings_skip_call_log">تخطي سجل المكالمات</string>
     <string name="settings_skip_notification">تخطي الإشعار</string>
     <string name="sim_1_allow_description">السماح بجميع المكالمات من شريحة الاتصال SIM 1.</string>
+    <string name="sim_1_block_description">حظر جميع المكالمات من الشريحة 1.</string>
     <string name="sim_2_allow_description">السماح بجميع المكالمات من شريحة الاتصال SIM 2.</string>
+    <string name="sim_2_block_description">حظر جميع المكالمات من الشريحة 2.</string>
     <string name="contacted_call_out_description">السماح بالمكالمات من الأرقام التي اتصلت بها.</string>
     <string name="messages_notification_description">السماح مؤقتا بالمكالمات من أرقام الهواتف المحمولة الموجودة في نص الرسائل الواردة.</string>
     <string name="settings_controller_description">تمكين جهاز استقبال البث من التحكم في الصمت بقصد.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,9 +50,11 @@
     <string name="settings_reject_call_description">Legt fest, ob der eingehende Anruf getrennt werden soll, als ob der Benutzer ihn manuell abgelehnt hätte. Diese Option sollte nur aktiviert werden, wenn der Anruf nicht zugelassen ist.</string>
     <string name="settings_skip_call_log_description">Legt fest, ob der eingehende Anruf nicht in der Anrufliste angezeigt werden soll. Diese Option sollte nur aktiviert werden, wenn der Anruf nicht zugelassen ist. Die Anrufe werden weiterhin mit dem Typ BLOCKED_TYPE protokolliert.</string>
     <string name="sim_1_allow_description">Alle Anrufe von SIM 1 zulassen.</string>
+    <string name="sim_1_block_description">Alle Anrufe von SIM 1 blockieren.</string>
     <string name="settings_silence_call_description">Legt fest, ob das Klingeln für den eingehenden Anruf stummgeschaltet werden soll. Der Anruf wird jedoch weiterhin an die Standard-Dialer-App weitergeleitet, wenn er nicht blockiert ist. Die Aktivierung dieser Option ist nur dann sinnvoll, wenn der Anruf nicht blockiert wurde.</string>
     <string name="settings_skip_notification_description">Legt fest, ob für den eingehenden Anruf keine Benachrichtigung über einen verpassten Anruf angezeigt werden soll. Diese Option sollte nur aktiviert werden, wenn der Anruf nicht zugelassen ist.</string>
     <string name="sim_2_allow_description">Alle Anrufe von SIM 2 zulassen.</string>
+    <string name="sim_2_block_description">Alle Anrufe von SIM 2 blockieren.</string>
     <string name="messages_ttl_helper_text">Wie lange die Nummer Sie anrufen kann. Modifikatoren: Tage [d], Stunden [h], Minuten [m]</string>
     <string name="messages_ttl_hint">zeit</string>
     <string name="messages_ttl_error">7 Tage / 48 Stunden / 120 Minuten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -17,12 +17,14 @@
     <string name="panic_app_unknown_app">una aplicación desconocida</string>
     <string name="sim_1">Tarjeta SIM 1</string>
     <string name="sim_1_allow_description">Permitir todas las llamadas desde la SIM 1.</string>
+    <string name="sim_1_block_description">Bloquear todas las llamadas desde la SIM 1.</string>
     <string name="extra">Más información</string>
     <string name="block_description">Bloquear todas las llamadas entrantes. Para bloquear también los números de los contactos hay que conceder un permiso.</string>
     <string name="block_main">Bloquear</string>
     <string name="extra_contacts">Contactos</string>
     <string name="sim_2">Tarjeta SIM 2</string>
     <string name="sim_2_allow_description">Permitir todas las llamadas desde la Tarjeta SIM 2.</string>
+    <string name="sim_2_block_description">Bloquear todas las llamadas desde la SIM 2.</string>
     <string name="extra_unknown_numbers_description">Permitir llamadas de extraños sin número.</string>
     <string name="extra_short_numbers">Números cortos</string>
     <string name="extra_short_numbers_description">Permitir llamadas desde números con una longitud de 3 a 5 dígitos.</string>
@@ -79,8 +81,8 @@
     <string name="regex_pattern_error">¡Expresión regular no válida!</string>
     <string name="sim_description">Permitir todas las llamadas desde una o ambas tarjetas SIM.</string>
     <string name="back">Volver</string>
-    <string name="activate_app">Apagar</string>
-    <string name="deactivate_app">Encender</string>
+    <string name="activate_app">Apagado</string>
+    <string name="deactivate_app">Encendido</string>
     <string name="contacted_call_in">Respuesta</string>
     <string name="contacted_call_in_description">Permitir llamadas de números que ya ha contestado.</string>
     <string name="extra_description">Permitir llamadas de algunos grupos/identificadores varios.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -39,8 +39,10 @@
     <string name="settings_skip_notification_description">不在着信通知がスキップされるかの設定。この設定は電話を防ぐ設定がセレクトした場合にのみセレクトしてください。</string>
     <string name="sim_1">SIM 1</string>
     <string name="sim_1_allow_description">SIM 1 からの電話を許可する。</string>
+    <string name="sim_1_block_description">SIM 1 からの全ての電話をブロックする。</string>
     <string name="sim_2">SIM 2</string>
     <string name="sim_2_allow_description">SIM 2 からの電話を許可する。</string>
+    <string name="sim_2_block_description">SIM 2 からの全ての電話をブロックする。</string>
     <string name="panic_app_dialog_message">%1$sにパニック作用を許可することを確認しますか。</string>
     <string name="panic_app_dialog_title">パニックアプリを確認</string>
     <string name="panic_app_unknown_app">未知のアプリ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -29,8 +29,10 @@
     <string name="sim">SIM</string>
     <string name="sim_1">SIM 1</string>
     <string name="sim_1_allow_description">Leisti visus skambučius iš SIM 1.</string>
+    <string name="sim_1_block_description">Blokuoti visus skambučius iš SIM 1.</string>
     <string name="sim_2">SIM 2</string>
     <string name="sim_2_allow_description">Leisti visus skambučius iš SIM 2.</string>
+    <string name="sim_2_block_description">Blokuoti visus skambučius iš SIM 2.</string>
     <string name="extra">Papildoma</string>
     <string name="extra_contacts">Kontaktai</string>
     <string name="extra_contacts_description">Leisti skambučius iš adresinėje esančių numerių.</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -41,7 +41,9 @@
     <string name="block_description">Blokker alle innkommende anrop. For å blokkere nummer fra kontakter også må du innvilge tilgang.</string>
     <string name="sim">SIM</string>
     <string name="sim_1_allow_description">Tillat alle anrop fra SIM 1.</string>
+    <string name="sim_1_block_description">Blokker alle anrop fra SIM 1.</string>
     <string name="sim_2_allow_description">Tillat alle anrop fra SIM 2.</string>
+    <string name="sim_2_block_description">Blokker alle anrop fra SIM 2.</string>
     <string name="extra_short_numbers_description">Tillat anrop med nummer på 3 til 5 siffer.</string>
     <string name="extra_contacts">Kontakter</string>
     <string name="extra_plus_numbers">Pluss-numre</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -42,8 +42,10 @@
     <string name="block_description">Blokkeer alle inkomende oproepen. Om nummers van contacten te blokkeren, moet u autorisatie geven.</string>
     <string name="sim_1">SIM 1</string>
     <string name="sim_1_allow_description">Sta alle oproepen toe van SIM 1.</string>
+    <string name="sim_1_block_description">Blokkeer alle oproepen van SIM 1.</string>
     <string name="sim_2">SIM 2</string>
     <string name="sim_2_allow_description">Sta alle oproepen toe van SIM 2.</string>
+    <string name="sim_2_block_description">Blokkeer alle oproepen van SIM 2.</string>
     <string name="extra">Verder</string>
     <string name="extra_contacts">Contact</string>
     <string name="extra_contacts_description">Sta oproepen toe van telefoonnummers in uw contacten.</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -26,8 +26,10 @@
     <string name="messages_ttl_helper_text">ਨੰਬਰ ਤੁਹਾਨੂੰ ਕਿੰਨਾ ਚਿਰ ਕਾਲ ਕਰਨ ਦੇ ਸਮਰੱਥ ਹੋਵੇਗਾ। ਸੋਧਕ: [d]ays [h]ours [m]inutes</string>
     <string name="sim">ਸਿਮ</string>
     <string name="sim_1_allow_description">ਪਹਿਲੀ ਸਿਮ ਤੋਂ ਸਾਰੀਆਂ ਕਾਲਾਂ ਦੀ ਮਨਜ਼ੂਰੀ ਦਿਓ।</string>
+    <string name="sim_1_block_description">ਪਹਿਲੀ ਸਿਮ ਤੋਂ ਸਾਰੀਆਂ ਕਾਲਾਂ ਨੂੰ ਬਲਾਕ ਕਰੋ।</string>
     <string name="sim_2">ਦੂਜੀ ਸਿਮ</string>
     <string name="sim_2_allow_description">ਦੂਜੀ ਸਿਮ ਤੋਂ ਸਾਰੀਆਂ ਕਾਲਾਂ ਦੀ ਮਨਜ਼ੂਰੀ ਦਿਓ।</string>
+    <string name="sim_2_block_description">ਦੂਜੀ ਸਿਮ ਤੋਂ ਸਾਰੀਆਂ ਕਾਲਾਂ ਨੂੰ ਬਲਾਕ ਕਰੋ।</string>
     <string name="extra_contacts_description">ਆਪਣੇ ਸੰਪਰਕਾਂ ਵਿੱਚਲੇ ਨੰਬਰਾਂ ਤੋਂ ਕਾਲਾਂ ਦੀ ਮਨਜ਼ੂਰੀ ਦਿਓ।</string>
     <string name="extra_unknown_numbers">ਅਣਪਛਾਤੇ ਨੰਬਰ</string>
     <string name="extra_unknown_numbers_description">ਬਿਨਾਂ ਨੰਬਰ ਵਾਲੇ ਓਪਰੇ ਲੋਕਾਂ ਦੀਆਂ ਕਾਲਾਂ ਨੂੰ ਮਨਜ਼ੂਰੀ ਦਿਓ।</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -39,7 +39,9 @@
     <string name="settings_skip_notification">Pomiń powiadomienie</string>
     <string name="settings_skip_notification_description">Określa, czy powiadomienie o nieodebranym połączeniu nie powinno być wyświetlane dla połączenia przychodzącego. To powinno być włączone tylko wtedy, gdy połączenie jest odrzucone.</string>
     <string name="sim_1_allow_description">Zezwalaj na wszystkie połączenia z karty SIM 1.</string>
+    <string name="sim_1_block_description">Blokuj wszystkie połączenia z karty SIM 1.</string>
     <string name="sim_2_allow_description">Zezwalaj na wszystkie połączenia z karty SIM 2.</string>
+    <string name="sim_2_block_description">Blokuj wszystkie połączenia z karty SIM 2.</string>
     <string name="goto_button">IDŹ</string>
     <string name="messages_notification_description">Tymczasowo zezwalaj na połączenia od numerów telefonów komórkowych znalezionych w treści wiadomości przychodzących.</string>
     <string name="settings_silence_call">Wycisz połączenie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -45,8 +45,10 @@
     <string name="settings_skip_call_log">Pular o registro de ligações</string>
     <string name="goto_button">IR_PARA</string>
     <string name="sim_1_allow_description">Permitir todas as ligações do SIM 1.</string>
+    <string name="sim_1_block_description">Bloquear todas as ligações do SIM 1.</string>
     <string name="settings_controller_description">Ativar o receptor de transmissão para controlar o Silêncio com intents.</string>
     <string name="sim_2_allow_description">Permitir todas as ligações do SIM 2.</string>
+    <string name="sim_2_block_description">Bloquear todas as ligações do SIM 2.</string>
     <string name="extra_short_numbers_description">Permitir ligações de números que contêm de 3 a 5 dígitos.</string>
     <string name="settings_silence_call_description">Define se o som de toque deve ser silenciado para ligação recebida. A própria ligação, se não for bloqueada, ainda será enviada ao app de discagem padrão. Esta opção só é válida se você escolheu não bloquear as ligações.</string>
     <string name="settings_skip_call_log_description">Define se a ligação recebida deve ou não ser exibida no registro de ligações. Isto só deve ser selecionado se a ligação for bloqueada. As ligações ainda serão registradas como BLOCKED_TYPE.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -5,6 +5,7 @@
     <string name="block_main">Bloquear</string>
     <string name="block_description">Bloquear todas as chamadas recebidas. Para também bloquear números de contactos, tem de conceder a permissão.</string>
     <string name="sim_2_allow_description">Permitir todas as chamadas do SIM 2.</string>
+    <string name="sim_2_block_description">Bloquear todas as chamadas do SIM 2.</string>
     <string name="settings_disallow_call">Bloquear chamada</string>
     <string name="settings_skip_notification">Não notificar</string>
     <string name="panic_app_dialog_message">Tem a certeza de que quer permitir que %1$s desencadeie ações de pânico destrutivas\?</string>
@@ -45,6 +46,7 @@
     <string name="sim">SIM</string>
     <string name="sim_1">SIM 1</string>
     <string name="sim_1_allow_description">Permitir todas as chamadas do SIM 1.</string>
+    <string name="sim_1_block_description">Bloquear todas as chamadas do SIM 1.</string>
     <string name="sim_2">SIM 2</string>
     <string name="extra">Extra</string>
     <string name="extra_contacts">Contactos</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -16,6 +16,7 @@
     <string name="extra_unknown_numbers_description">Permitir chamadas de desconhecidos com número oculto.</string>
     <string name="messages_ttl_error">7d / 48h / 120m</string>
     <string name="sim_2_allow_description">Permitir todas as chamadas do SIM 2.</string>
+    <string name="sim_2_block_description">Bloquear todas as chamadas do SIM 2.</string>
     <string name="extra_stir_description">Permitir chamadas de números que passam a verificação STRI.</string>
     <string name="settings_reject_call_description">Define se a chamada recebida deve ser rejeitada automaticamente como se o utilizador a tivesse rejeitado manualmente. Isso só deve ser ativado se a chamada for bloqueada.</string>
     <string name="settings_silence_call_description">Define se o toque da chamada recebida deve ser silenciado. No entanto a chamada ainda será enviada para a aplicação de chamadas padrão, se não estiver bloqueada. Ativar isto só faz sentido quando a chamada não foi bloqueada.</string>
@@ -44,6 +45,7 @@
     <string name="sim">SIM</string>
     <string name="sim_1">SIM 1</string>
     <string name="sim_1_allow_description">Permitir todas as chamadas do SIM 1.</string>
+    <string name="sim_1_block_description">Bloquear todas as chamadas do SIM 1.</string>
     <string name="sim_2">SIM 2</string>
     <string name="extra">Extra</string>
     <string name="extra_contacts">Contactos</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -51,7 +51,9 @@
     <string name="settings_skip_call_log_description">Устанавливает, должен ли входящий вызов отображаться в журнале вызовов. Вызовы по-прежнему будут регистрироваться с типом BLOCKED_TYPE.</string>
     <string name="settings_skip_notification">Пропускать уведомления</string>
     <string name="sim_1_allow_description">Разрешить все вызовы для SIM 1.</string>
+    <string name="sim_1_block_description">Заблокировать все вызовы с SIM 1.</string>
     <string name="sim_2_allow_description">Разрешить все вызовы для SIM 2.</string>
+    <string name="sim_2_block_description">Заблокировать все вызовы с SIM 2.</string>
     <string name="extra_contacts">Контакты</string>
     <string name="extra_contacts_description">Разрешить звонки с номеров в контактах.</string>
     <string name="extra_plus_numbers">Международные номера</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -44,8 +44,10 @@
     <string name="block_main">தொகுதி</string>
     <string name="block_description">உள்வரும் அனைத்து அழைப்புகளையும் தடுக்கவும். தொடர்புகளிலிருந்து எண்களைத் தடுக்க நீங்கள் இசைவு வழங்க வேண்டும்.</string>
     <string name="sim_1_allow_description">சிம் 1 இலிருந்து அனைத்து அழைப்புகளையும் அனுமதிக்கவும்.</string>
+    <string name="sim_1_block_description">சிம் 1 இலிருந்து அனைத்து அழைப்புகளையும் தடுக்கவும்.</string>
     <string name="sim_2">சிம் 2</string>
     <string name="sim_2_allow_description">சிம் 2 இலிருந்து அனைத்து அழைப்புகளையும் அனுமதிக்கவும்.</string>
+    <string name="sim_2_block_description">சிம் 2 இலிருந்து அனைத்து அழைப்புகளையும் தடுக்கவும்.</string>
     <string name="extra">கூடுதல்</string>
     <string name="extra_contacts">தொடர்புகள்</string>
     <string name="extra_contacts_description">உங்கள் தொடர்புகளில் உள்ள எண்களிலிருந்து அழைப்புகளை அனுமதிக்கவும்.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -48,7 +48,9 @@
     <string name="settings_skip_call_log_description">Gelen aramanın arama günlüğünde görüntülenmemesi gerekip gerekmediğini ayarlar. Bu yalnızca aramaya izin verilmiyorsa işaretlenmelidir. Aramalar yine de BLOCKED_TYPE türüyle kaydedilecektir.</string>
     <string name="settings_skip_notification_description">Gelen arama için bir cevapsız arama bildiriminin gösterilmemesi gerekip gerekmediğini ayarlar. Bu yalnızca aramaya izin verilmiyorsa işaretlenmelidir.</string>
     <string name="sim_1_allow_description">SIM 1\'den gelen tüm aramalara izin ver.</string>
+    <string name="sim_1_block_description">SIM 1\'den gelen tüm aramaları engelle.</string>
     <string name="sim_2_allow_description">SIM 2\'den gelen tüm aramalara izin ver.</string>
+    <string name="sim_2_block_description">SIM 2\'den gelen tüm aramaları engelle.</string>
     <string name="messages_notification_description">Gelen mesajlar metninde bulunan cep telefonu numaralarından gelen aramalara geçici olarak izin ver.</string>
     <string name="settings_controller_description">Genel yayın alıcısının Silence\'ı intent\'lerle denetlemesini etkinleştirir.</string>
     <string name="settings_disallow_call_description">Gelen aramanın engellenip engellenmeyeceğini ayarlar.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -38,8 +38,10 @@
     <string name="block_description">封鎖所有來電。若要同時封鎖聯絡人的號碼，你必須授予權限。</string>
     <string name="sim_1">SIM 1</string>
     <string name="sim_1_allow_description">允許來自 SIM 1 的所有來電。</string>
+    <string name="sim_1_block_description">封鎖來自 SIM 1 的所有來電。</string>
     <string name="sim_2">SIM 2</string>
     <string name="sim_2_allow_description">允許來自 SIM 2 的所有來電。</string>
+    <string name="sim_2_block_description">封鎖來自 SIM 2 的所有來電。</string>
     <string name="messages_ttl_hint">時間</string>
     <string name="messages_notification">文字</string>
     <string name="messages_ttl_error">7 天／48 小時／120 分鐘</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.1"
+agp = "8.12.1"
 kotlin = "2.2.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"


### PR DESCRIPTION
# Description
This PR addresses issues with contact permission logic, localizes the SIM Card section, and improves the user experience for blocked call notifications.

## Key Changes
**Logic Fix**: Resolved the issue where the "allow calls from contacts" option was not being read correctly.

**Localization:**  Localized SIM Card section labels for all languages (except KO, HI, FA, DA, UK, and OR, which lack the sim_allow_description base keys).

- Corrected Spanish translation for the main On/Off toggle.

**UX Improvements:**

- Contact Names: Blocked call notifications now display the contact name instead of just the number.

- Permissions: "Allow calls from contacts" is now disabled by default.

- Validation: Added a Toast message to prevent enabling the feature if Contact permissions haven't been granted.

<img width="595" height="628" alt="Contact name in notification" src="https://github.com/user-attachments/assets/9e9fb771-7f4d-41d8-bd5f-c301658f1aa4" />

![Toggle detect permission contact](https://github.com/user-attachments/assets/d8cc0320-003e-4005-958e-26f0f117c6a2)

